### PR TITLE
fix cache size

### DIFF
--- a/src/main/res/values/strings_mapsforge.xml
+++ b/src/main/res/values/strings_mapsforge.xml
@@ -74,7 +74,7 @@
     <string name="preferences_general">General settings</string>
     <string name="preferences_cache_persistence">Cache persistence</string>
     <string name="preferences_cache_persistence_desc">Keep cached images on exit</string>
-    <string name="preferences_cache_size">External storage</string>
+    <string name="preferences_cache_size">Cache size</string>
     <string name="preferences_cache_size_desc">Adjust the size of the cache</string>
     <string name="preferences_cache_size_value">%.1f MB</string>
     <string name="preferences_fullscreen">Full screen mode</string>


### PR DESCRIPTION
`strings_pref` fix:     
In all languages the coordinates have a `.` not a `,` - also in Arabic, Korean etc.

`strings_mapsforge` fix:     
Description for the cache used from this app.
The cache is not the external storage.